### PR TITLE
Remove bitbox-sdk dependency to reduce bitbox-sdk installation time and package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "unit": "tape test/*.js"
   },
   "dependencies": {
-    "bitbox-cli": "1.5.*",
     "keccak": "^1.3.0",
     "nyc": "*",
     "standard": "^11.0.1",


### PR DESCRIPTION
bitbox-sdk is currently not used in bip32-utils.

If bitbox-sdk can be removed as a dependency in the package that would reduce the installation time and size of bitbox-sdk.